### PR TITLE
Enable running on the IPCC node

### DIFF
--- a/bin/diag_run
+++ b/bin/diag_run
@@ -18,10 +18,10 @@ EYR1=-1
 CASE2=none
 SYR2=-1
 EYR2=-1
-if [ -d /tos-project1/NS2345K/noresm/cases ]; then
-    WEB_PATH=/tos-project1/NS2345K/www/diagnostics/$ROOT_FOLD/$USER
-    HISTORY_PATH1=/tos-project1/NS2345K/noresm/cases
-    HISTORY_PATH2=/tos-project1/NS2345K/noresm/cases
+if [ -d /projects/NS2345K/noresm/cases ]; then
+    WEB_PATH=/projects/NS2345K/www/diagnostics/noresm/$USER
+    HISTORY_PATH1=/projects/NS2345K/noresm/cases
+    HISTORY_PATH2=/projects/NS2345K/noresm/cases
 else
     echo "NO default input and out path set"
     #echo "*** EXIT ***"

--- a/packages/BLOM_DIAG/blom_diag_template.sh
+++ b/packages/BLOM_DIAG/blom_diag_template.sh
@@ -7,9 +7,9 @@
 # built upon previous work by Detelina Ivanova
 # Last update Aug. 2019
 
-if [ -d /opt/ncl65 ] && [ -d /opt/nco475 ] && [ -d /opt/cdo195 ]; then
+if [ -d /opt/ncl65 ] && [ -d /opt/nco475 ] && [ -d /opt/cdo197 ]; then
     export NCARG_ROOT=/opt/ncl65
-    export PATH=/opt/ncl65/bin/:/opt/nco475/bin/:/opt/cdo195/bin:/usr/local/bin:/usr/bin
+    export PATH=/usr/local/bin:/usr/bin:/opt/ncl65/bin/:/opt/nco475/bin/:/opt/cdo197/bin
     source /opt/intel/compilers_and_libraries/linux/bin/compilervars.sh -arch intel64 -platform linux
 else
     module -q purge
@@ -115,7 +115,7 @@ NINO_INDICES=3,34
 # ---------------------------------------------------------
 # Publish the html on the NIRD web server, and set the path
 # where it should be published. If the path is left empty,
-# it is set to /projects/NS2345K/www/noresm_diagnostics.
+# it is set to /projects/NS2345K/www/noresm.
 # The figures are converted to png. The quality of the
 # figures is determined by the density variable.
 publish_html=1 # (1=ON,0=OFF)
@@ -1178,7 +1178,7 @@ tar -cf $TARFILE $WEBFOLDER
 if [ $? -eq 0 ] && [ $publish_html -eq 1 ]; then
     web_server_path=/projects/NS2345K/www
     if [ -z $publish_html_root ]; then
-        publish_html_root=${web_server_path}/noresm_diagnostics
+        publish_html_root=${web_server_path}/diagnostics/noresm
     fi
     publish_html_path=$publish_html_root/$CASENAME1/BLOM_DIAG
     if [ ! -d $publish_html_path ]; then

--- a/packages/BLOM_DIAG/blom_diag_template.sh
+++ b/packages/BLOM_DIAG/blom_diag_template.sh
@@ -1195,7 +1195,7 @@ if [ $? -eq 0 ] && [ $publish_html -eq 1 ]; then
     if [ $? -eq 0 ]; then
         if [ $path_pref == $web_server_path ]; then
             full_url=${web_server}/${path_suff}/${WEBFOLDER}/indexnew.html
-            $DIAG_CODE/redirect_html.sh $WEBFOLDER $publish_html_path $full_url
+            $DIAG_CODE/redirect_html.sh $WEBFOLDER $publish_html_path ${WEBFOLDER}/indexnew.html
             echo " "
             echo "URL:"
             echo "***********************************************************************************"

--- a/packages/CAM_DIAG/amwg_template.csh
+++ b/packages/CAM_DIAG/amwg_template.csh
@@ -8,12 +8,12 @@
 
 unset echo verbose
 setenv DIAG_VERSION 140207  # version number YYMMDD
-if ( -d /opt/ncl65 && -d /opt/nco475 && -d /opt/cdo195 ) then
+if ( -d /opt/ncl65 && -d /opt/nco475 && -d /opt/cdo197 ) then
     setenv NCARG_ROOT /opt/ncl65
-    setenv PATH /opt/ncl65/bin/:/opt/nco475/bin/:/opt/cdo195/bin:/usr/local/bin:/usr/bin
+    setenv PATH /usr/local/bin:/usr/bin:/opt/ncl65/bin/:/opt/nco475/bin/:/opt/cdo197/bin
     source /opt/intel/compilers_and_libraries/linux/bin/compilervars.csh -arch intel64 -platform linux
     setenv nco_dir  /opt/nco475/bin
-    setenv cdo_dir  /opt/cdo195/bin
+    setenv cdo_dir  /opt/cdo197/bin
 else
     module -q purge
     module -q load NCO/4.7.2-intel-2018a
@@ -241,7 +241,7 @@ set cntl_last_yr_ts = lyr_of_ts_cntl
 # (does only work in conjunction with web_pages = 0 [default]),
 # and set the path where it should be published.
 # If the path is left empty it is set to
-# /projects/NS2345K/www/noresm_diagnostics
+# /projects/NS2345K/www/noresm
 # The URL will appear in the terminal right before the termination
 # of this script, as well as in ${test_path_diag}/URL
 
@@ -3374,7 +3374,7 @@ endif
 if ($web_pages == 0 && $publish_html == 0) then
    set web_server_path = /projects/NS2345K/www
    if ( "$publish_html_root" == "" ) then
-      set publish_html_root = ${web_server_path}/noresm_diagnostics
+      set publish_html_root = ${web_server_path}/noresm
    endif
    set publish_html_path = $publish_html_root/$test_casename/CAM_DIAG
    if (! -e ${publish_html_path}) then

--- a/packages/CAM_DIAG/amwg_template.csh
+++ b/packages/CAM_DIAG/amwg_template.csh
@@ -3401,7 +3401,7 @@ if ($web_pages == 0 && $publish_html == 0) then
          echo "${full_url}"
          echo "***********************************************************************************"
          echo "COPY AND PASTE THE URL INTO THE ADDRESS BAR OF YOUR WEB BROWSER TO VIEW THE RESULTS"
-         $HTML_HOME/redirect_html.csh $tardir $publish_html_path $full_url
+         $HTML_HOME/redirect_html.csh $tardir $publish_html_path ${tardir}/sets.htm
       else
          echo "THE HTML FILES ARE LOCATED IN:"
          echo "${publish_html_path}/${tardir}"

--- a/packages/CAM_DIAG/amwg_template.csh
+++ b/packages/CAM_DIAG/amwg_template.csh
@@ -12,7 +12,8 @@ if ( -d /opt/ncl65 && -d /opt/nco475 && -d /opt/cdo197 ) then
     setenv NCARG_ROOT /opt/ncl65
     setenv PATH /usr/local/bin:/usr/bin:/opt/ncl65/bin/:/opt/nco475/bin/:/opt/cdo197/bin
     source /opt/intel/compilers_and_libraries/linux/bin/compilervars.csh -arch intel64 -platform linux
-    setenv nco_dir  /opt/nco475/bin
+    setenv ncksbin  `which ncks`
+    setenv nco_dir  `dirname $ncksbin`
     setenv cdo_dir  /opt/cdo197/bin
 else
     module -q purge

--- a/packages/CICE_DIAG/ice_diag_template.csh
+++ b/packages/CICE_DIAG/ice_diag_template.csh
@@ -882,7 +882,7 @@ if ($web_pages == 1 && $publish_html == 1) then
          echo " ${full_url}                                                                        "
          echo " ***********************************************************************************"
          echo " COPY AND PASTE THE URL INTO THE ADDRESS BAR OF YOUR WEB BROWSER TO VIEW THE RESULTS"
-         ${DIAG_HOME}/web/redirect_html.csh $TAR_FILE $publish_html_path $full_url
+         ${DIAG_HOME}/web/redirect_html.csh $TAR_FILE $publish_html_path ${TAR_FILE}/index.html
       else
          echo " THE HTML FILES ARE LOCATED IN:                                                     "
          echo " ${publish_html_path}/${TAR_FILE}                                                   "

--- a/packages/CICE_DIAG/ice_diag_template.csh
+++ b/packages/CICE_DIAG/ice_diag_template.csh
@@ -11,7 +11,7 @@ unset echo verbose
 setenv HOSTNAME `hostname -f`
 if  ( `echo $HOSTNAME |grep 'nird'` !="" ) then
     setenv NCARG_ROOT /opt/ncl65
-    setenv PATH /opt/ncl65/bin/:/opt/nco475/bin/:/opt/cdo195/bin:/usr/local/bin:/usr/bin
+    setenv PATH /usr/local/bin:/usr/bin:/opt/ncl65/bin/:/opt/nco475/bin/:/opt/cdo197/bin
     source /opt/intel/compilers_and_libraries/linux/bin/compilervars.csh -arch intel64 -platform linux
     setenv ncclimo_dir  /opt/nco475/bin
 else if ( `echo $HOSTNAME |grep 'fram'` !="" ) then
@@ -172,7 +172,7 @@ set KEEP_PS_FILES = 0            # Keep .ps files, 1 = yes
 # web_pages = 1 creates a tar file with all figures and html
 # publish_html = 1 publishes the html in $publish_html_root
 # on NIRD. If publish_html_root is left empty, it will be set
-# to /projects/NS2345K/www/noresm_diagnostics
+# to /projects/NS2345K/www/noresm
 
 set web_pages         = 1                 # 1 --> true
 set publish_html      = 1
@@ -854,7 +854,7 @@ rm -rf $TAR_FILE
 if ($web_pages == 1 && $publish_html == 1) then
    set web_server_path = /projects/NS2345K/www
    if ( "$publish_html_root" == "" ) then
-      set publish_html_root = ${web_server_path}/noresm_diagnostics
+      set publish_html_root = ${web_server_path}/noresm
    endif
    set publish_html_path = ${publish_html_root}/${CASE_TO_CONT}/CICE_DIAG
    if (! -e ${publish_html_path}) then

--- a/packages/CICE_DIAG/ice_diag_template.csh
+++ b/packages/CICE_DIAG/ice_diag_template.csh
@@ -13,7 +13,8 @@ if  ( `echo $HOSTNAME |grep 'nird'` !="" ) then
     setenv NCARG_ROOT /opt/ncl65
     setenv PATH /usr/local/bin:/usr/bin:/opt/ncl65/bin/:/opt/nco475/bin/:/opt/cdo197/bin
     source /opt/intel/compilers_and_libraries/linux/bin/compilervars.csh -arch intel64 -platform linux
-    setenv ncclimo_dir  /opt/nco475/bin
+    setenv ncksbin  `which ncks`
+    setenv ncclimo_dir  `dirname $ncksbin`
 else if ( `echo $HOSTNAME |grep 'fram'` !="" ) then
     module -q purge
     module -q load NCO/4.7.2-intel-2018a

--- a/packages/CLM_DIAG/code/shared/lnd_driver.csh
+++ b/packages/CLM_DIAG/code/shared/lnd_driver.csh
@@ -848,7 +848,7 @@ if($web_pages == 1) then
    if ($publish_html == 1) then
       set web_server_path = /projects/NS2345K/www
       if ( "$publish_html_root" == "" ) then
-         set publish_html_root = ${web_server_path}/noresm_diagnostics
+         set publish_html_root = ${web_server_path}/noresm
       endif
       set publish_html_path = ${publish_html_root}/${caseid_1}/CLM_DIAG
       if (! -e ${publish_html_path}) then

--- a/packages/CLM_DIAG/code/shared/lnd_driver.csh
+++ b/packages/CLM_DIAG/code/shared/lnd_driver.csh
@@ -876,7 +876,7 @@ if($web_pages == 1) then
             echo "${full_url}"
             echo "***********************************************************************************"
             echo "COPY AND PASTE THE URL INTO THE ADDRESS BAR OF YOUR WEB BROWSER TO VIEW THE RESULTS"
-            ${DIAG_SHARED}/redirect_html.csh $WEBFOLD $publish_html_path $full_url
+            ${DIAG_SHARED}/redirect_html.csh $WEBFOLD $publish_html_path ${tardir}/setsIndex.html
          else
             echo "THE HTML FILES ARE LOCATED IN:"
             echo "${publish_html_path}/${tardir}"

--- a/packages/CLM_DIAG/lnd_template.csh
+++ b/packages/CLM_DIAG/lnd_template.csh
@@ -1,9 +1,9 @@
 #!/bin/csh
 
 # Version lnd_template4.2.25.csh
-if ( -d /opt/ncl65 && -d /opt/nco475 && -d /opt/cdo195 ) then
+if ( -d /opt/ncl65 && -d /opt/nco475 && -d /opt/cdo197 ) then
     setenv NCARG_ROOT /opt/ncl65
-    setenv PATH /opt/ncl65/bin/:/opt/nco475/bin/:/opt/cdo195/bin:/usr/local/bin:/usr/bin
+    setenv PATH /opt/ncl65/bin/:/opt/nco475/bin/:/opt/cdo197/bin:/usr/local/bin:/usr/bin
     source /opt/intel/compilers_and_libraries/linux/bin/compilervars.csh -arch intel64 -platform linux
     setenv ncclimo_dir  /opt/nco475/bin/
 else

--- a/packages/CLM_DIAG/lnd_template.csh
+++ b/packages/CLM_DIAG/lnd_template.csh
@@ -5,7 +5,8 @@ if ( -d /opt/ncl65 && -d /opt/nco475 && -d /opt/cdo197 ) then
     setenv NCARG_ROOT /opt/ncl65
     setenv PATH /opt/ncl65/bin/:/opt/nco475/bin/:/opt/cdo197/bin:/usr/local/bin:/usr/bin
     source /opt/intel/compilers_and_libraries/linux/bin/compilervars.csh -arch intel64 -platform linux
-    setenv ncclimo_dir  /opt/nco475/bin/
+    setenv ncksbin  `which ncks`
+    setenv ncclimo_dir  `dirname $ncksbin`
 else
     module -q purge
     module -q load NCO/4.7.2-intel-2018a

--- a/packages/HAMOCC_DIAG/hamocc_diag_template.sh
+++ b/packages/HAMOCC_DIAG/hamocc_diag_template.sh
@@ -830,7 +830,7 @@ if [ $? -eq 0 ] && [ $publish_html -eq 1 ]; then
     if [ $? -eq 0 ]; then
         if [ $path_pref == $web_server_path ]; then
             full_url=${web_server}/${path_suff}/${WEBFOLDER}/index.html
-            $DIAG_CODE/redirect_html.sh $WEBFOLDER $publish_html_path $full_url
+            $DIAG_CODE/redirect_html.sh $WEBFOLDER $publish_html_path ${WEBFOLDER}/index.htm
             echo " "
             echo "URL:"
             echo "***********************************************************************************"

--- a/packages/HAMOCC_DIAG/hamocc_diag_template.sh
+++ b/packages/HAMOCC_DIAG/hamocc_diag_template.sh
@@ -5,9 +5,9 @@
 # Johan Liakka, NERSC, johan.liakka@nersc.no
 # Last Update, Sept. 2020, yanchun.he@nersc.no
 
-if [ -d /opt/ncl65 ] && [ -d /opt/nco475 ] && [ -d /opt/cdo195 ]; then
+if [ -d /opt/ncl65 ] && [ -d /opt/nco475 ] && [ -d /opt/cdo197 ]; then
     export NCARG_ROOT=/opt/ncl65
-    export PATH=/opt/ncl65/bin/:/opt/nco475/bin/:/opt/cdo195/bin:/usr/local/bin:/usr/bin
+    export PATH=/usr/local/bin:/usr/bin:/opt/ncl65/bin/:/opt/nco475/bin/:/opt/cdo197/bin
     source /opt/intel/compilers_and_libraries/linux/bin/compilervars.sh -arch intel64 -platform linux
 else
     module -q purge
@@ -105,7 +105,7 @@ set_4=1 # (1=ON,0=OFF) Regionally-averaged monthly climatology plots
 # ---------------------------------------------------------
 # Publish the html on the NIRD web server, and set the path
 # where it should be published. If the path is left empty,
-# it is set to /projects/NS2345K/www/noresm_diagnostics.
+# it is set to /projects/NS2345K/www/noresm.
 # The figures are converted to png. The quality of the
 # figures is determined by the density variable. You can
 # also choose the colormap for the full fields
@@ -813,7 +813,7 @@ tar -cf $TARFILE $WEBFOLDER
 if [ $? -eq 0 ] && [ $publish_html -eq 1 ]; then
     web_server_path=/projects/NS2345K/www
     if [ -z $publish_html_root ]; then
-        publish_html_root=${web_server_path}/noresm_diagnostics
+        publish_html_root=${web_server_path}/noresm
     fi
     publish_html_path=$publish_html_root/$CASENAME1/HAMOCC_DIAG
     if [ ! -d $publish_html_path ]; then


### PR DESCRIPTION
*  enable running on the IPCC node
*  change default output to path /projects/NS2345K/www/diagnostics/noresm/
*  fix nco path
* use relative path for redirect html page

close #11 