### PR TITLE
Port to Betzy login nodes; Upgrade after NIRD maintenance..

### DIFF
--- a/packages/BLOM_DIAG/blom_diag_template.sh
+++ b/packages/BLOM_DIAG/blom_diag_template.sh
@@ -7,24 +7,26 @@
 # built upon previous work by Detelina Ivanova
 # Last update Aug. 2019
 
-if [ -d /opt/ncl65 ] && [ -d /opt/nco475 ] && [ -d /opt/cdo197 ]; then
+## LOAD MODULES AND SET ENVIRONMENTS
+HOST="$(uname -a) $(hostname -f)"
+if [ "$(echo $HOST |grep 'ipcc.nird')" ];then
     export NCARG_ROOT=/opt/ncl65
     export NCARG_COLORMAPS=$NCARG_ROOT/lib/ncarg/colormaps
     export PATH=/usr/local/bin:/usr/bin:/opt/ncl65/bin/:/opt/nco475/bin/:/opt/cdo197/bin
-    source /opt/intel/compilers_and_libraries/linux/bin/compilervars.sh -arch intel64 -platform linux
+elif [ "$(echo $HOST |grep 'login[0-9].nird')" ];then
+     export NCARG_ROOT=/usr
+     export NCARG_COLORMAPS=$NCARG_ROOT/lib/ncarg/colormaps
+elif [ "$(echo $HOST |grep 'betzy')" ]; then
+     module -q purge
+     module -q load NCO/4.9.3-intel-2019b
+     module -q load CDO/1.9.8-intel-2019b
+     module -q load NCL/6.6.2-intel-2019b
 else
-    module -q purge
-    module -q load NCO/4.7.2-intel-2018a
-    module -q load CDO/1.9.3-intel-2018a
-    module -q load NCL/6.5.0-intel-2018a   # NCL must be loaded after NCO/CDO
-    module -q unload LibTIFF/4.0.9-GCCcore-6.4.0
+    echo "** UNKNOWN HOST $HOST **"
+    echo "** EXIT                   **"
+    exit
 fi
-which ncks &>/dev/null
-if [ $? -ne 0 ];then
-    echo "UNKNOW HOSTNAME: $HOSTNAME "
-    echo "*** EXIT ***"
-    exit 1
-fi
+
 #***************************
 #*** USER MODIFY SECTION ***
 #***************************

--- a/packages/BLOM_DIAG/blom_diag_template.sh
+++ b/packages/BLOM_DIAG/blom_diag_template.sh
@@ -701,6 +701,12 @@ mkdir -m 775 -p $WEBDIR/set4
 mkdir -m 775 -p $WEBDIR/set5
 mkdir -m 775 -p $WEBDIR/set6
 mkdir -m 775 -p $WEBDIR/set7
+if [ ! -d $WEBDIR ]
+then
+    echo "** ERROR: making web folder: $WEBDIR **"
+    echo "**                 EXIT              **"
+    exit 1
+fi
 
 export cinfo=1model
 if [ $CNTL == USER ]; then

--- a/packages/BLOM_DIAG/code/compute_ann_time_series.sh
+++ b/packages/BLOM_DIAG/code/compute_ann_time_series.sh
@@ -205,9 +205,9 @@ do
                 fi
                 $NCKS --quiet -d depth,0 -d x,0 -d y,0 -v dp,parea $WKDIR/$filename >/dev/null 2>&1
                 if [ $? -eq 0 ]; then
-                    $NCAP2 -O -s 'dmass=dp*parea' $WKDIR/$filename  -o $WKDIR/$filename >/dev/null 2>&1
+                    $NCAP2 -O -s 'dmass=dp*parea' $WKDIR/$filename  $WKDIR/$filename >/dev/null 2>&1
                     if [ $? -ne 0 ]; then
-                        echo "ERROR: $NCAP2 -O -s 'dmass=dp*parea' $WKDIR/$filename  -o $WKDIR/$filename >/dev/null 2>&1"
+                        echo "ERROR: $NCAP2 -O -s 'dmass=dp*parea' $WKDIR/$filename  $WKDIR/$filename >/dev/null 2>&1"
                         exit
                     fi
                 fi

--- a/packages/CAM_DIAG/amwg_template.csh
+++ b/packages/CAM_DIAG/amwg_template.csh
@@ -8,29 +8,33 @@
 
 unset echo verbose
 setenv DIAG_VERSION 140804  # version number YYMMDD
-if ( -d /opt/ncl65 && -d /opt/nco475 && -d /opt/cdo197 ) then
+
+## LOAD MODULES AND SET ENVIRONMENTS
+HOST="$(uname -a) $(hostname -f)"
+if ( "$(echo $HOST |grep 'ipcc.nird')" ) then
     setenv NCARG_ROOT /opt/ncl65
     setenv NCARG_COLORMAPS $NCARG_ROOT/lib/ncarg/colormaps
-    setenv PATH /usr/bin://usr/local/bin:opt/ncl65/bin/:/opt/nco475/bin/:/opt/cdo197/bin
-    source /opt/intel/compilers_and_libraries/linux/bin/compilervars.csh -arch intel64 -platform linux
+    setenv PATH /usr/local/bin:/usr/bin:/opt/ncl65/bin/:/opt/nco475/bin/:/opt/cdo197/bin
     setenv ncksbin  `which ncks`
     setenv nco_dir  `dirname $ncksbin`
     setenv cdo_dir  /opt/cdo197/bin
-else
+else if ( "$(echo $HOST |grep 'login[0-9].nird')" ) then
+    setenv NCARG_ROOT /usr
+    setenv NCARG_COLORMAPS $NCARG_ROOT/lib/ncarg/colormaps
+    setenv ncksbin  `which ncks`
+    setenv nco_dir  `dirname $ncksbin`
+    setenv cdo_dir  /opt/cdo197/bin
+else if ( "$(echo $HOST |grep 'betzy')" )  then
     module -q purge
-    module -q load NCO/4.7.2-intel-2018a
-    module -q load CDO/1.9.3-intel-2018a
-    module -q load NCL/6.5.0-intel-2018a   # NCL must be loaded after NCO/CDO
-    module -q unload LibTIFF/4.0.9-GCCcore-6.4.0
+    module -q load NCO/4.9.3-intel-2019b
+    module -q load CDO/1.9.8-intel-2019b
+    module -q load NCL/6.6.2-intel-2019b
     setenv nco_dir  ${EBROOTNCO}/bin
     setenv cdo_dir  ${EBROOTCDO}/bin
-endif
-which ncks >&/dev/null
-set rcode=$status
-if ( $rcode != 0 ) then
-    echo "UNKNOW HOSTNAME: $HOSTNAME "
-    echo "*** EXIT ***"
-    exit 1
+else
+    echo "** UNKNOWN HOST $HOST **"
+    echo "**       EXIT         **"
+    exit
 endif
 
 #******************************************************************

--- a/packages/CAM_DIAG/amwg_template.csh
+++ b/packages/CAM_DIAG/amwg_template.csh
@@ -1554,6 +1554,11 @@ if ($web_pages == 0) then
         setenv WEBDIR ${test_path_diag}/yrs${test_first_yr}to${test_end}-yrs${cntl_first_yr}to${cntl_end}
       endif
       if (! -e $WEBDIR) mkdir -m 775 $WEBDIR
+      if (! -e ${WEBDIR}) then
+         echo ERROR: Unable to create \$WEBDIR: ${WEBDIR}
+         echo "***EXITING THE SCRIPT"
+         exit 1
+      endif
       if (-e $WEBDIR && `stat -c %a $WEBDIR` != 775 ) chmod 775 $WEBDIR
       cd $WEBDIR
       $HTML_HOME/setup_2models $test_casename $cntl_casename $image yrs${test_first_yr}to${test_end} yrs${cntl_first_yr}to${cntl_end}

--- a/packages/CICE_DIAG/ice_diag_template.csh
+++ b/packages/CICE_DIAG/ice_diag_template.csh
@@ -8,26 +8,32 @@ unset echo verbose
 # - Better performance climatology computation (ncclimo)
 # - Updated web interface for NIRD
 # - NCL updates to version 4.6.0.
-setenv HOSTNAME `hostname -f`
-if  ( `echo $HOSTNAME |grep 'nird'` !="" ) then
+
+## LOAD MODULES AND SET ENVIRONMENTS
+HOST="$(uname -a) $(hostname -f)"
+if ( "$(echo $HOST |grep 'ipcc.nird')" ) then
     setenv NCARG_ROOT /opt/ncl65
     setenv NCARG_COLORMAPS $NCARG_ROOT/lib/ncarg/colormaps
     setenv PATH /usr/local/bin:/usr/bin:/opt/ncl65/bin/:/opt/nco475/bin/:/opt/cdo197/bin
-    source /opt/intel/compilers_and_libraries/linux/bin/compilervars.csh -arch intel64 -platform linux
     setenv ncksbin  `which ncks`
     setenv ncclimo_dir  `dirname $ncksbin`
-else if ( `echo $HOSTNAME |grep 'fram'` !="" ) then
+else if ( "$(echo $HOST |grep 'login[0-9].nird')" ) then
+    setenv NCARG_ROOT /usr
+    setenv NCARG_COLORMAPS $NCARG_ROOT/lib/ncarg/colormaps
+    setenv ncksbin  `which ncks`
+    setenv ncclimo_dir  `dirname $ncksbin`
+else if ( "$(echo $HOST |grep 'betzy')" )  then
     module -q purge
-    module -q load NCO/4.7.2-intel-2018a
-    module -q load CDO/1.9.3-intel-2018a
-    module -q load NCL/6.5.0-intel-2018a   # NCL must be loaded after NCO/CDO
-    module -q unload LibTIFF/4.0.9-GCCcore-6.4.0
+    module -q load NCO/4.9.3-intel-2019b
+    module -q load CDO/1.9.8-intel-2019b
+    module -q load NCL/6.6.2-intel-2019b
     setenv ncclimo_dir  ${EBROOTNCO}/bin
 else
-    echo "UNKNOW HOSTNAME: $HOSTNAME "
-    echo "*** EXIT ***"
-    exit 1
+    echo "** UNKNOWN HOST $HOST **"
+    echo "**       EXIT         **"
+    exit
 endif
+
 #--------------------------------------------------------------------#
 #----------------- USER DEFINED INPUT -------------------------------#
 #--------------------------------------------------------------------#

--- a/packages/CISM_DIAG/cism_diag_template.sh
+++ b/packages/CISM_DIAG/cism_diag_template.sh
@@ -5,23 +5,26 @@
 # Heiko Goelzer, NORCE, heig@norceresearch.no 
 # Last update 11.01.2022
 
-if [ -d /opt/ncl65 ] && [ -d /opt/nco475 ] && [ -d /opt/cdo197 ]; then
+## LOAD MODULES AND SET ENVIRONMENTS
+HOST="$(uname -a) $(hostname -f)"
+if [ "$(echo $HOST |grep 'ipcc.nird')" ];then
     export NCARG_ROOT=/opt/ncl65
+    export NCARG_COLORMAPS=$NCARG_ROOT/lib/ncarg/colormaps
     export PATH=/usr/local/bin:/usr/bin:/opt/ncl65/bin/:/opt/nco475/bin/:/opt/cdo197/bin
-    source /opt/intel/compilers_and_libraries/linux/bin/compilervars.sh -arch intel64 -platform linux
+elif [ "$(echo $HOST |grep 'login[0-9].nird')" ];then
+     export NCARG_ROOT=/usr
+     export NCARG_COLORMAPS=$NCARG_ROOT/lib/ncarg/colormaps
+elif [ "$(echo $HOST |grep 'betzy')" ]; then
+     module -q purge
+     module -q load NCO/4.9.3-intel-2019b
+     module -q load CDO/1.9.8-intel-2019b
+     module -q load NCL/6.6.2-intel-2019b
 else
-    module -q purge
-    module -q load NCO/4.7.2-intel-2018a
-    module -q load CDO/1.9.3-intel-2018a
-    module -q load NCL/6.5.0-intel-2018a   # NCL must be loaded after NCO/CDO
-    module -q unload LibTIFF/4.0.9-GCCcore-6.4.0
+    echo "** UNKNOWN HOST $HOST **"
+    echo "** EXIT                   **"
+    exit
 fi
-which ncks &>/dev/null
-if [ $? -ne 0 ];then
-    echo "UNKNOW HOSTNAME: $HOSTNAME "
-    echo "*** EXIT ***"
-    exit 1
-fi
+
 #***************************
 #*** USER MODIFY SECTION ***
 #***************************

--- a/packages/CISM_DIAG/cism_diag_template.sh
+++ b/packages/CISM_DIAG/cism_diag_template.sh
@@ -482,6 +482,12 @@ export WEBDIR=$WKDIR/$WEBFOLDER
 #fi
 mkdir -m 775 -p $WEBDIR/set1
 mkdir -m 775 -p $WEBDIR/set2
+if [ ! -d $WEBDIR ]
+then
+    echo "** ERROR: making web folder: $WEBDIR **"
+    echo "**                 EXIT              **"
+    exit 1
+fi
 
 export cinfo=1model
 if [ $CNTL == USER ]; then

--- a/packages/CLM_DIAG/lnd_template.csh
+++ b/packages/CLM_DIAG/lnd_template.csh
@@ -1,28 +1,32 @@
 #!/bin/csh
 
 # Version lnd_template4.2.25.csh
-if ( -d /opt/ncl65 && -d /opt/nco475 && -d /opt/cdo197 ) then
+
+## LOAD MODULES AND SET ENVIRONMENTS
+HOST="$(uname -a) $(hostname -f)"
+if ( "$(echo $HOST |grep 'ipcc.nird')" ) then
     setenv NCARG_ROOT /opt/ncl65
     setenv NCARG_COLORMAPS $NCARG_ROOT/lib/ncarg/colormaps
-    setenv PATH /opt/ncl65/bin/:/opt/nco475/bin/:/opt/cdo197/bin:/usr/local/bin:/usr/bin
-    source /opt/intel/compilers_and_libraries/linux/bin/compilervars.csh -arch intel64 -platform linux
+    setenv PATH /usr/local/bin:/usr/bin:/opt/ncl65/bin/:/opt/nco475/bin/:/opt/cdo197/bin
     setenv ncksbin  `which ncks`
     setenv ncclimo_dir  `dirname $ncksbin`
-else
+else if ( "$(echo $HOST |grep 'login[0-9].nird')" ) then
+    setenv NCARG_ROOT /usr
+    setenv NCARG_COLORMAPS $NCARG_ROOT/lib/ncarg/colormaps
+    setenv ncksbin  `which ncks`
+    setenv ncclimo_dir  `dirname $ncksbin`
+else if ( "$(echo $HOST |grep 'betzy')" )  then
     module -q purge
-    module -q load NCO/4.7.2-intel-2018a
-    module -q load CDO/1.9.3-intel-2018a
-    module -q load NCL/6.5.0-intel-2018a   # NCL must be loaded after NCO/CDO
-    module -q unload LibTIFF/4.0.9-GCCcore-6.4.0
+    module -q load NCO/4.9.3-intel-2019b
+    module -q load CDO/1.9.8-intel-2019b
+    module -q load NCL/6.6.2-intel-2019b
     setenv ncclimo_dir  ${EBROOTNCO}/bin
+else
+    echo "** UNKNOWN HOST $HOST **"
+    echo "**       EXIT         **"
+    exit
 endif
-which ncks >&/dev/null
-set rcode=$status
-if ( $rcode != 0 ) then
-    echo "UNKNOW HOSTNAME: $HOSTNAME "
-    echo "*** EXIT ***"
-    exit 1
-endif
+
 # NOTE: You MUST use ncl/6.2.0 (e.g., module load ncl/6.2.0)
 
 # NOTE: For running the non-swift version of this script, you MUST use

--- a/packages/HAMOCC_DIAG/code/functions_time_series.ncl
+++ b/packages/HAMOCC_DIAG/code/functions_time_series.ncl
@@ -178,7 +178,7 @@ end
 
 function get_talklvl100m (inptr:file) 
 begin
-   if (isfilevar(inptr,"talklvl")) then
+   if (isfilevar(inptr,"talklvl100m")) then
       tmp = inptr->talklvl100m
       if (typeof(tmp).eq."double") then
          xvar = dble2flt(tmp)

--- a/packages/HAMOCC_DIAG/hamocc_diag_template.sh
+++ b/packages/HAMOCC_DIAG/hamocc_diag_template.sh
@@ -637,6 +637,12 @@ mkdir -m 775 -p $WEBDIR/set1
 mkdir -m 775 -p $WEBDIR/set2
 mkdir -m 775 -p $WEBDIR/set3
 mkdir -m 775 -p $WEBDIR/set4
+if [ ! -d $WEBDIR ]
+then
+    echo "** ERROR: making web folder: $WEBDIR **"
+    echo "**                 EXIT              **"
+    exit 1
+fi
 cp $DIAG_HTML/index.html $WEBDIR
 cdate=`date`
 sed -i "s/test_run/$CASENAME1/g" $WEBDIR/index.html

--- a/packages/HAMOCC_DIAG/hamocc_diag_template.sh
+++ b/packages/HAMOCC_DIAG/hamocc_diag_template.sh
@@ -5,24 +5,26 @@
 # Johan Liakka, NERSC, johan.liakka@nersc.no
 # Last Update, Sept. 2020, yanchun.he@nersc.no
 
-if [ -d /opt/ncl65 ] && [ -d /opt/nco475 ] && [ -d /opt/cdo197 ]; then
+## LOAD MODULES AND SET ENVIRONMENTS
+HOST="$(uname -a) $(hostname -f)"
+if [ "$(echo $HOST |grep 'ipcc.nird')" ];then
     export NCARG_ROOT=/opt/ncl65
     export NCARG_COLORMAPS=$NCARG_ROOT/lib/ncarg/colormaps
     export PATH=/usr/local/bin:/usr/bin:/opt/ncl65/bin/:/opt/nco475/bin/:/opt/cdo197/bin
-    source /opt/intel/compilers_and_libraries/linux/bin/compilervars.sh -arch intel64 -platform linux
+elif [ "$(echo $HOST |grep 'login[0-9].nird')" ];then
+     export NCARG_ROOT=/usr
+     export NCARG_COLORMAPS=$NCARG_ROOT/lib/ncarg/colormaps
+elif [ "$(echo $HOST |grep 'betzy')" ]; then
+     module -q purge
+     module -q load NCO/4.9.3-intel-2019b
+     module -q load CDO/1.9.8-intel-2019b
+     module -q load NCL/6.6.2-intel-2019b
 else
-    module -q purge
-    module -q load NCO/4.7.2-intel-2018a
-    module -q load CDO/1.9.3-intel-2018a
-    module -q load NCL/6.5.0-intel-2018a   # NCL must be loaded after NCO/CDO
-    module -q unload LibTIFF/4.0.9-GCCcore-6.4.0
+    echo "** UNKNOWN HOST $HOST **"
+    echo "** EXIT                   **"
+    exit
 fi
-which ncks &>/dev/null
-if [ $? -ne 0 ];then
-    echo "UNKNOW HOSTNAME: $HOSTNAME "
-    echo "*** EXIT ***"
-    exit 1
-fi
+
 #***************************
 #*** USER MODIFY SECTION ***
 #***************************


### PR DESCRIPTION
* Fixes in accordance to NIRD maintenance on [07-04-2022](https://opslog.sigma2.no/2022/03/31/maintenance-nird-tos-2/)
   + fix ncap2 of NCO 4.8.1 on NIRD does not support `-o` option
  + fix error, ncap2 calculated global average copies 2D parea instead make 1D parea in the annual average file; it complains when merge the different annual mean files of different variables into one single file
* Improve performance of adding attributes to variables]
* Port to Betzy login nodes
* Add test to web folder

close #17 